### PR TITLE
Add support for Llama2, Palm, Cohere, Anthropic, Replicate, Azure Models - using litellm

### DIFF
--- a/src/utils/models.py
+++ b/src/utils/models.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 from dotenv import load_dotenv
-from langchain.chat_models import ChatAnthropic, ChatOpenAI
+from langchain.chat_models import ChatAnthropic, ChatOpenAI, ChatLiteLLM
 from langchain.chat_models.base import BaseChatModel
 from langchain.llms import OpenAI
 from langchain.schema import BaseMessage
@@ -20,20 +20,7 @@ def get_chat_model(name: ChatModelName, **kwargs) -> BaseChatModel:
         del kwargs["model_name"]
     if "model" in kwargs:
         del kwargs["model"]
-
-    if name == ChatModelName.TURBO:
-        return ChatOpenAI(model_name=name.value, **kwargs)
-    elif name == ChatModelName.GPT4:
-        return ChatOpenAI(model_name=name.value, **kwargs)
-    elif name == ChatModelName.CLAUDE:
-        return ChatAnthropic(model=name.value, **kwargs)
-    elif name == ChatModelName.CLAUDE_INSTANT:
-        return ChatAnthropic(model=name.value, **kwargs)
-    elif name == ChatModelName.WINDOW:
-        return ChatWindowAI(model_name=name.value, **kwargs)
-    else:
-        raise ValueError(f"Invalid model name: {name}")
-
+    return ChatLiteLLM(model_name=name.value, **kwargs)
 
 class ChatModel:
     """Wrapper around the ChatModel class."""


### PR DESCRIPTION
This PR adds support for 50+ models with a standard I/O interface using litellm: https://github.com/BerriAI/litellm/

`ChatLiteLLM()` is integrated into langchain and allows you to call all models using the ChatOpenAI I/O interface 
https://python.langchain.com/docs/integrations/chat/litellm

Here's an example of how to use ChatLiteLLM()
```python
ChatLiteLLM(model="gpt-3.5-turbo")
ChatLiteLLM(model="claude-2", temperature=0.3)
ChatLiteLLM(model="command-nightly")
ChatLiteLLM(model="replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1")

```