### PR TITLE
Fix for werkzeug update issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ hyperdb-python = "^0.1.3"
 quart = "^0.18.4"
 anthropic = "^0.2.10"
 websocket-client = "^1.5.2"
+werkzeug = "2.2.3"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
Seems like the werkzeug version automatically installed by poetry (Werkzeug 3.0 update) has a breaking change (removal of the "url_decode" function)

Adding the previous version with the "url_decode" function seems to solve this issue. I've added the update to the dependencies list, this pull request fixes #105